### PR TITLE
Create BuildConstants.java

### DIFF
--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -1,0 +1,19 @@
+package frc.robot;
+
+/**
+ * Automatically generated file containing build version information.
+ */
+public final class BuildConstants {
+  public static final String MAVEN_GROUP = "";
+  public static final String MAVEN_NAME = "";
+  public static final String VERSION = "";
+  public static final int GIT_REVISION = 0;
+  public static final String GIT_SHA = "";
+  public static final String GIT_DATE = "";
+  public static final String GIT_BRANCH = "";
+  public static final String BUILD_DATE = "";
+  public static final long BUILD_UNIX_TIME = 0;
+  public static final int DIRTY = 0;
+
+  private BuildConstants(){}
+}


### PR DESCRIPTION
Creates a initial file for `BuildConstants.java`, ensuring that there is no error message when initially building the codebase.