### PR TITLE
SparkRelativeEncoderSims

### DIFF
--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIOSim.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIOSim.java
@@ -3,6 +3,7 @@ package frc.robot.subsystems.elevator;
 import java.util.Random;
 
 import com.revrobotics.sim.SparkFlexSim;
+import com.revrobotics.sim.SparkRelativeEncoderSim;
 
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.wpilibj.simulation.ElevatorSim;
@@ -13,6 +14,10 @@ import frc.robot.util.LaserCanWrapper.LaserCanSim;
 public class ElevatorIOSim extends ElevatorIOVortex {
  
     private final SparkFlexSim motor = new SparkFlexSim(super.leadMotor, DCMotor.getNeoVortex(2));
+
+    private final SparkRelativeEncoderSim leadEncoder = new SparkRelativeEncoderSim(super.leadMotor);
+    private final SparkRelativeEncoderSim followerEncoder = new SparkRelativeEncoderSim(super.followerMotor);
+
     private final LaserCanSim laserCan = super.laserCan.getSimulatedDevice();
 
     private final ElevatorSim elevator = new ElevatorSim(
@@ -27,6 +32,14 @@ public class ElevatorIOSim extends ElevatorIOVortex {
     );
 
     private final Random random = new Random();
+
+    public ElevatorIOSim () {
+
+        super();
+
+        this.leadEncoder.setPosition(super.leadEncoder.getPosition());
+        this.followerEncoder.setPosition(super.followerEncoder.getPosition());
+    }
 
     @Override
     public void updateInputs(ElevatorIOInputs inputs) {

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIOVortex.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIOVortex.java
@@ -4,6 +4,7 @@ import org.littletonrobotics.junction.networktables.LoggedNetworkBoolean;
 
 import com.revrobotics.spark.SparkBase.PersistMode;
 import com.revrobotics.spark.SparkBase.ResetMode;
+import com.revrobotics.RelativeEncoder;
 import com.revrobotics.spark.SparkFlex;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
 import com.revrobotics.spark.config.SparkFlexConfig;
@@ -15,7 +16,10 @@ public class ElevatorIOVortex implements ElevatorIO {
     private final LoggedNetworkBoolean manual = new LoggedNetworkBoolean("Manual Elevator", false);
 
     protected final SparkFlex leadMotor = new SparkFlex(ElevatorConstants.LEADER_CAN, MotorType.kBrushless);
-    private final SparkFlex followerMotor = new SparkFlex(ElevatorConstants.FOLLOWER_CAN, MotorType.kBrushless);
+    protected final SparkFlex followerMotor = new SparkFlex(ElevatorConstants.FOLLOWER_CAN, MotorType.kBrushless);
+    
+    protected final RelativeEncoder leadEncoder = this.leadMotor.getEncoder();
+    protected final RelativeEncoder followerEncoder = this.followerMotor.getEncoder();
     
     protected final LaserCanWrapper laserCan = new LaserCanWrapper(ElevatorConstants.LASER_CAN);
 

--- a/src/main/java/frc/robot/subsystems/end_effector/EndEffectorIOSim.java
+++ b/src/main/java/frc/robot/subsystems/end_effector/EndEffectorIOSim.java
@@ -2,6 +2,7 @@ package frc.robot.subsystems.end_effector;
 
 import com.revrobotics.sim.SparkFlexSim;
 import com.revrobotics.sim.SparkLimitSwitchSim;
+import com.revrobotics.sim.SparkRelativeEncoderSim;
 
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.system.plant.LinearSystemId;
@@ -17,6 +18,10 @@ public class EndEffectorIOSim extends EndEffectorIOVortex {
     private final SparkFlexSim coralIntakeMotor = new SparkFlexSim(super.coralIntakeMotor, DCMotor.getNeoVortex(1));
     private final SparkFlexSim algaeIntakeMotor = new SparkFlexSim(super.algaeIntakeMotor, DCMotor.getNeoVortex(1));
     private final SparkFlexSim algaeWristMotor = new SparkFlexSim(super.algaeWristMotor, DCMotor.getNeoVortex(1));
+
+    private final SparkRelativeEncoderSim coralIntakeEncoder = new SparkRelativeEncoderSim(super.coralIntakeMotor);
+    private final SparkRelativeEncoderSim algaeIntakeEncoder = new SparkRelativeEncoderSim(super.algaeIntakeMotor);
+    private final SparkRelativeEncoderSim algaeWristEncoder = new SparkRelativeEncoderSim(super.algaeWristMotor);
 
     private final SparkLimitSwitchSim coralBeambreak = this.coralIntakeMotor.getForwardLimitSwitchSim();
 
@@ -52,6 +57,15 @@ public class EndEffectorIOSim extends EndEffectorIOVortex {
         true, 
         Units.degreesToRadians(90.0)
     );
+
+    public EndEffectorIOSim () {
+
+        super();
+
+        this.coralIntakeEncoder.setPosition(super.coralIntakeEncoder.getPosition());
+        this.algaeIntakeEncoder.setPosition(super.algaeIntakeEncoder.getPosition());
+        this.algaeWristEncoder.setPosition(super.algaeWristEncoder.getPosition());
+    }
 
     @Override
     public void updateInputs(EndEffectorIOInputs inputs) {

--- a/src/main/java/frc/robot/subsystems/end_effector/EndEffectorIOVortex.java
+++ b/src/main/java/frc/robot/subsystems/end_effector/EndEffectorIOVortex.java
@@ -4,6 +4,7 @@ import org.littletonrobotics.junction.networktables.LoggedNetworkBoolean;
 
 import com.revrobotics.spark.SparkBase.PersistMode;
 import com.revrobotics.spark.SparkBase.ResetMode;
+import com.revrobotics.RelativeEncoder;
 import com.revrobotics.spark.SparkFlex;
 import com.revrobotics.spark.SparkLimitSwitch;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
@@ -17,6 +18,10 @@ public class EndEffectorIOVortex implements EndEffectorIO {
     protected final SparkFlex coralIntakeMotor = new SparkFlex(EndEffectorConstants.CORAL_INTAKE_CAN, MotorType.kBrushless);
     protected final SparkFlex algaeIntakeMotor = new SparkFlex(EndEffectorConstants.ALGAE_INTAKE_CAN, MotorType.kBrushless);
     protected final SparkFlex algaeWristMotor = new SparkFlex(EndEffectorConstants.ALGAE_WRIST_CAN, MotorType.kBrushless);
+
+    protected final RelativeEncoder coralIntakeEncoder = this.coralIntakeMotor.getEncoder();
+    protected final RelativeEncoder algaeIntakeEncoder = this.algaeIntakeMotor.getEncoder();
+    protected final RelativeEncoder algaeWristEncoder = this.algaeWristMotor.getEncoder();
 
     private final SparkLimitSwitch coralBeambreak = coralIntakeMotor.getForwardLimitSwitch();
 

--- a/src/main/java/frc/robot/subsystems/funnel/FunnelIOSim.java
+++ b/src/main/java/frc/robot/subsystems/funnel/FunnelIOSim.java
@@ -1,6 +1,7 @@
 package frc.robot.subsystems.funnel;
 
 import com.revrobotics.sim.SparkFlexSim;
+import com.revrobotics.sim.SparkRelativeEncoderSim;
 
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.system.plant.LinearSystemId;
@@ -11,6 +12,7 @@ import frc.robot.util.CurrentDrawSim;
 public class FunnelIOSim extends FunnelIOVortex {
 
     private final SparkFlexSim motor = new SparkFlexSim(super.motor, DCMotor.getNeoVortex(1));
+    private final SparkRelativeEncoderSim encoder = new SparkRelativeEncoderSim(super.motor);
 
     private final FlywheelSim funnel = new FlywheelSim(
         LinearSystemId.createFlywheelSystem(
@@ -20,6 +22,13 @@ public class FunnelIOSim extends FunnelIOVortex {
         ), 
         DCMotor.getNeoVortex(1)
     );
+
+    public FunnelIOSim () {
+
+        super();
+        
+        this.encoder.setPosition(super.encoder.getPosition());
+    }
 
     @Override
     public void updateInputs (FunnelIOInputsAutoLogged inputs) {

--- a/src/main/java/frc/robot/subsystems/funnel/FunnelIOVortex.java
+++ b/src/main/java/frc/robot/subsystems/funnel/FunnelIOVortex.java
@@ -2,6 +2,7 @@ package frc.robot.subsystems.funnel;
 
 import com.revrobotics.spark.SparkBase.PersistMode;
 import com.revrobotics.spark.SparkBase.ResetMode;
+import com.revrobotics.RelativeEncoder;
 import com.revrobotics.spark.SparkFlex;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
 import com.revrobotics.spark.config.SparkFlexConfig;
@@ -9,6 +10,7 @@ import com.revrobotics.spark.config.SparkFlexConfig;
 public class FunnelIOVortex implements FunnelIO {
     
     protected final SparkFlex motor = new SparkFlex(FunnelConstants.FUNNEL_CAN, MotorType.kBrushless);
+    protected final RelativeEncoder encoder = this.motor.getEncoder();
 
     public FunnelIOVortex () {
 

--- a/src/main/java/frc/robot/util/BuildConstants.java
+++ b/src/main/java/frc/robot/util/BuildConstants.java
@@ -7,12 +7,12 @@ public final class BuildConstants {
   public static final String MAVEN_GROUP = "";
   public static final String MAVEN_NAME = "Reefscape2025";
   public static final String VERSION = "unspecified";
-  public static final int GIT_REVISION = 334;
-  public static final String GIT_SHA = "22b98747ede7c39096c463f5e3bf606ab8be986c";
-  public static final String GIT_DATE = "2025-05-29 04:52:43 CDT";
-  public static final String GIT_BRANCH = "only_simulation";
-  public static final String BUILD_DATE = "2025-05-29 05:24:24 CDT";
-  public static final long BUILD_UNIX_TIME = 1748514264943L;
+  public static final int GIT_REVISION = 335;
+  public static final String GIT_SHA = "91697717636e46c4344ce62e0bcf68fc2d0420e4";
+  public static final String GIT_DATE = "2025-05-29 05:30:37 CDT";
+  public static final String GIT_BRANCH = "simulation";
+  public static final String BUILD_DATE = "2025-07-16 12:01:56 CDT";
+  public static final long BUILD_UNIX_TIME = 1752685316081L;
   public static final int DIRTY = 1;
 
   private BuildConstants(){}


### PR DESCRIPTION
Implement simulations of the SPARK Flex relative encoders to allow for the initial positions of the real objects to be overwritten while running in simulation in the Vortex IO constructors.